### PR TITLE
Compatibility fix for Python 3

### DIFF
--- a/src/topia/termextract/extract.py
+++ b/src/topia/termextract/extract.py
@@ -57,8 +57,8 @@ def _keepterm(multiterm, terms, KEEP_ORIGINAL_SPACING):
     terms.setdefault(word, 0)
     terms[word] += 1
 
+@zope.interface.implementer(interfaces.ITermExtractor)
 class TermExtractor(object):
-    zope.interface.implements(interfaces.ITermExtractor)
 
     def __init__(self, tagger=None, filter=None):
         if tagger is None:

--- a/src/topia/termextract/tag.py
+++ b/src/topia/termextract/tag.py
@@ -104,8 +104,8 @@ def normalizePluralForms(idx, tagged_term, tagged_terms, lexicon):
             return
 
 
+@zope.interface.implementer(interfaces.ITagger)
 class Tagger(object):
-    zope.interface.implements(interfaces.ITagger)
 
     rules = (
         correctDefaultNounTag,


### PR DESCRIPTION
moving from Zope "implements" to "@implementer"

I haven't tested this under Python 2, but it fixes an import-breaking issue with Python 3.